### PR TITLE
0.9.2 #1

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,8 +3,6 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   build-and-push:

--- a/README.md
+++ b/README.md
@@ -129,13 +129,21 @@ Using the table below, MAG `m1` will be submitted as a medium quality contig ass
 A submission can take several hours to complete. We recommend using [nohup](https://en.wikipedia.org/wiki/Nohup), [tmux](https://github.com/tmux/tmux/wiki) or something similar to prevent the process from being interrupted. 
 
 # Taxonomy Assignment
-Assemblies and bins need a valid NCBI taxonomy (scientific name and taxonomic identifier) for submission. If you did taxonomic annotation of bins based on [GTDB](https://gtdb.ecogenomic.org/), you can use the `gtdb_to_ncbi_majority_vote.py` script of the [GTDB-Toolkit](https://github.com/Ecogenomics/GTDBTk) to translate your results to NCBI taxonomy.
+Assemblies and bins need a valid NCBI taxonomy (scientific name and taxonomic identifier) for submission. While in most cases the assignment works automatically, it is important to note that [environmental organism-level taxonomy](https://ena-docs.readthedocs.io/en/latest/faq/taxonomy.html#environmental-organism-level-taxonomy) has to be used for metagenome submissions. For example: Consider a bin that was classified only on the class level and was determined to belong to class `Clostridia`. The taxonomy id of the class `Clostridia` is `186801`. However, the correct environmental organism-level taxonomy for the bin is `uncultured Clostridia bacterium` with the taxid `244328`.
 
+## GTDB-Toolkit Taxonomy
+If you did taxonomic annotation of bins based on [GTDB](https://gtdb.ecogenomic.org/), you can use the `gtdb_to_ncbi_majority_vote.py` script of the [GTDB-Toolkit](https://github.com/Ecogenomics/GTDBTk) to translate your results to NCBI taxonomy.
+
+## NCBI-Taxonomy
 You can provide tables with NCBI taxonomy information for each bin (see `./tests/bacteria_taxonomy.tsv` for an example - the output of `gtdb_to_ncbi_majority_vote.py` has the correct format already). submg will use ENAs [suggest-for-submission-sendpoint](https://ena-docs.readthedocs.io/en/latest/retrieval/programmatic-access/taxon-api.html) to derive taxids that follow the [rules for bin taxonomy](https://ena-docs.readthedocs.io/en/latest/faq/taxonomy.html).
 
+## Manually Specified Taxonomy
 Either in addition to those files, or as an alternative you can provide a `MANUAL_TAXONOMY` table. This should specify the correct taxids and scientific names for bins. An example of such a document can be found in `./examples/data/taxonomy/manual_taxonomy_3bins.tsv`. If a bin is present in this document, the taxonomic data from the NCBI taxonomy tables will be ignored.
 
-In some cases submg will be unable to assign a valid taxonomy to a bin. The submission will be aborted and you will be informed which bins are causing problems. In such cases you have to determine the correct scientific name and taxid for the bin and specify it in the `MANUAL_TAXONOMY` field of your config file. Sometimes the reason for a failed taxonomic assignment is that no proper taxid exists yet. You can [create a taxon request](https://ena-docs.readthedocs.io/en/latest/faq/taxonomy_requests.html) in the ENA Webin Portal to register the taxon.
+## Taxonomy Assignment Failure
+In some cases submg will be unable to assign a valid taxonomy to a bin. The submission will be aborted and you will be informed which bins are causing problems. In such cases you have to determine the correct scientific name and taxid for the bin and specify it in the `MANUAL_TAXONOMY` field of your config file. 
+
+A possible reason for a failed taxonomic assignment is that no proper taxid exists yet. This happens more often than one might expect. You can [create a taxon request](https://ena-docs.readthedocs.io/en/latest/faq/taxonomy_requests.html) in the ENA Webin Portal to register the taxon.
 
 ## NCBI Taxonomy File
 This file contains the NCBI taxonomy for bins. You can provide multiple taxonomy files covering different bins. If you created it with `gtdb_to_ncbi_majority_vote.py` of the [GTDB-Toolkit](https://github.com/Ecogenomics/GTDBTk) it will have the following, compatible format already. Alternatively, provide a .tsv file with the columns 'Bin_id' and 'NCBI_taxonomy'. The string in the 'NCBI_taxonomy' column has to adhere to the format shown below. Taxonomic ranks are separated by semicolons. On each rank, a letter indicating the rank is followed by two underscores and the classification at that rank. The ranks have to be in the order 'domain', 'phylum', 'class', 'order', 'family', 'genus', 'species'. If a classification at a certain rank is unavailable, the rank itself still needs to be present in the string (e.g. "s__").

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="submg/img/logo_dark.png">
   <source media="(prefers-color-scheme: light)" srcset="submg/img/logo_light.png">
-  <img align="left" alt="submg Logo" sr c="submg/img/logo_light.png" width=350>
+  <img align="left" alt="submg Logo" sr c="submg/img/logo_light.png" width=400>
 </picture>
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 </picture>
 
 
-submg aids in the submission of metagenomic study data to the European Nucleotide Archive. It can be used to submit various combinations of samples, reads, (co-)assemblies, bins and MAGs. After you enter your (meta)data in a configuration form, submg derives additional information where required, creates samplesheets and manifests and uploads everything to your ENA account. You can use a combination of manual and submg steps to submit your data (e.g. submitting samples and reads through the ENA web interface, then using the tool to submit the assembly and bins).
+subMG aids in the submission of metagenomic study data to the European Nucleotide Archive. It can be used to submit various combinations of samples, reads, (co-)assemblies, bins and MAGs. After you enter your (meta)data in a configuration form, subMG derives additional information where required, creates samplesheets and manifests and uploads everything to your ENA account. You can use a combination of manual and subMG steps to submit your data (e.g. submitting samples and reads through the ENA web interface, then using the tool to submit the assembly and bins).
 
 
 
@@ -54,10 +54,9 @@ Please Note
 
 # Installation
 
-## Container
 A container based on the main branch is available [through DockerHub](https://hub.docker.com/r/ttubb/submg): `docker pull ttubb/submg`
 
-## Local Installation
+If you want to install the tool locally, follow these steps:
 - Make sure Python 3.8 or higher is installed
 - Make sure Java 1.8 or higher is installed
 - Make sure [wheel](https://pypi.org/project/wheel/) is installed
@@ -157,7 +156,8 @@ ENA provides a [guideline for choosing taxonomy](https://ena-docs.readthedocs.io
 If your bins are the result of dereplicating data from a single assembly you can use submg as described above. If your bins are the result of dereplicating data from multiple different assemblies, you need to split them based on which assembly they belong to. You then run submg seperately for each assembly (together with the corresponding set of bins).
 
 # Bin Contamination above 100 percent
-When calculating completeness and contamination of a bin with tools like [CheckM](https://github.com/Ecogenomics/CheckM), contamination values above 100% can occur. [Usually, this is not an error](https://github.com/Ecogenomics/CheckM/issues/107). However, the ENA API will refuse to accept bins with contamination values above 100%. This issue is unrelated to submg, but to avoid partial submissions submg will refuse to work if such a bin is present in the dataset. If you have bins with contamination values above 100% you can either leave them out by removing them from your dataset or manually set the contamination value to 100% in the `BINS_QUALITY_FILE` file you provide to submg.
+When calculating completeness and contamination of a bin with tools like [CheckM](https://github.com/Ecogenomics/CheckM), contamination values above 100% can occur. [Usually, this is not an error](https://github.com/Ecogenomics/CheckM/issues/107). However, the ENA API will refuse to accept bins with contamination values above 100%. submg will automatically exclude bins with contamination values above 100% from the submission.
+If you _need_ to submit such (presumably low quality) bins, you need to manually set the contamination value to 100 in the 'QUALITY_FILE' you provide under the bins section.
 
 # Support
 submg is being actively developed. Please use the github [issue tracker](https://github.com/ttubb/submg/issues) to report problems. A [discussions page](https://github.com/ttubb/submg/discussions) is available for questions, comments and suggestions. 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 # Base Image
 FROM openjdk:slim
 
-
 # Set up environment
 RUN apt-get update && \
     apt-get upgrade -y

--- a/examples/02_samples_reads_assembly_bins.yaml
+++ b/examples/02_samples_reads_assembly_bins.yaml
@@ -47,7 +47,9 @@ BINS:
   QUALITY_FILE: "data/checkm_quality_2bins.tsv"                                                       # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
   NCBI_TAXONOMY_FILES: ["data/taxonomy/archaea_taxonomy.tsv", "data/taxonomy/bacteria_taxonomy.tsv"]  # A list of files with NCBI taxonomy information about the bins. Consult the README to see how they should be structured. >>EXAMPLE: ["/mnt/data/bacteria_tax.tsv","/mnt/data/archaea_tax.tsv"]
   MANUAL_TAXONOMY_FILE:                                                                               # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
-  BINNING_SOFTWARE: 'VAMB'                                                                            # The program that was used for binning. >>EXAMPLE: "metabat2"
+  BINNING_SOFTWARE: 'VAMB'         
+  MIN_COMPLETENESS: 50                                                        # Bins with smaller completeness value will be discarded (values in percent, 0-100). Remove this row to ignore bin completeness. >>EXAMPLE: "90"
+  MAX_CONTAMINATION: 10                                                       # Bins with larger contamination value will be discarded (values in percent, 0-100). Remove this row to ignore bin contamination (>100% contamination bins will still be discarded). >>EXAMPLE: "5"
   ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
   ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
 BAM_FILES:

--- a/examples/11_bins.yaml
+++ b/examples/11_bins.yaml
@@ -11,7 +11,7 @@ SEQUENCING_PLATFORMS: ["ILLUMINA"]                                            # 
 PROJECT_NAME: "Project ex11 idx00"                                            # Name of the project within which the sequencing was organized >>EXAMPLE: "AgRFex 2 Biogas Survey"
 SAMPLE_ACCESSIONS: ["SAMEA113417017"]                                         # These samples exist in ENA. Your assembly is based on them. >>EXAMPLE: ["ERS15898933","ERS15898932"]
 ASSEMBLY:                                         
-  ASSEMBLY_NAME: "idx00_ex11_asm"                                        # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
+  ASSEMBLY_NAME: "idx00_ex11_asm"                                             # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
   EXISTING_ASSEMBLY_ANALYSIS_ACCESSION: "ERZ21942150"                         # The accession of the assembly analysis that all bins/MAGs originate from >>EXAMPLE: "GCA_012552665"
   EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION:                                      # The accession of the virtual sample of the co-assembly which all bins/MAGs originate from >>EXAMPLE: "ERZ21942150"
   ASSEMBLY_SOFTWARE: "MEGAHIT"                                                # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
@@ -25,6 +25,7 @@ BINS:
   NCBI_TAXONOMY_FILES: "data/taxonomy/eukaryota_taxonomy.tsv"                 # A list of files with NCBI taxonomy information about the bins. Consult the README to see how they should be structured. >>EXAMPLE: ["/mnt/data/bacteria_tax.tsv","/mnt/data/archaea_tax.tsv"]  
   MANUAL_TAXONOMY_FILE: "data/taxonomy/manual_taxonomy_eukaryota.tsv"         # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
   BINNING_SOFTWARE: "metabat2"                                                # The program that was used for binning. >>EXAMPLE: "metabat2"
+  MAX_CONTAMINATION: 5                                                        # Bins with larger contamination value will be discarded (values in percent, 0-100). Remove this row to ignore bin contamination (>100% contamination bins will still be discarded). >>EXAMPLE: "5"
   ADDITIONAL_SAMPLESHEET_FIELDS:                                              # You can add more fields from the ENA samplesheet that most closely matches your experiment
   ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
   COVERAGE_FILE: "data/bin_coverage.tsv"                                      # .tsv file containing the coverage values of each bin. Columns must be 'Bin_id' and 'Coverage'.

--- a/examples/data/checkm_quality_3bins.tsv
+++ b/examples/data/checkm_quality_3bins.tsv
@@ -1,4 +1,4 @@
 Bin Id	Marker lineage	# genomes	# markers	# marker sets	0	1	2	3	4	5+	Completeness	Contamination	Strain heterogeneity
 bin1	k__Bacteria (UID2570)	433	273	183	101	172	0	0	0	0	62.22	0.10	0.10
-bin2	root (UID1)	5656	56	24	55	1	0	0	0	0	4.17	0.00	0.00
-bin3	k__Bacteria (UID203)	5449	104	58	84	20	0	0	0	0	23.90	0.00	0.00
+bin2	root (UID1)	5656	56	24	55	1	0	0	0	0	94.17	17.11	0.00
+bin3	k__Bacteria (UID203)	5449	104	58	84	20	0	0	0	0	23.90	1.20	0.00

--- a/examples/localtest.yaml
+++ b/examples/localtest.yaml
@@ -1,56 +1,56 @@
-# ABOUT: This is a config for submitting 2 set of paired end reads, an assembly and bins
-# ABOUT: Coverage is known.
-# ABOUT: Taxonomy is derived from `gtdb_to_ncbi_majority_vote.py` output and a MANUAL_TAXONOMY_FILE
+# ABOUT: This is a config for submitting 1 sample, 2 sets of single-end reads, an assembly and bins.
+# ABOUT: Coverage is derived from one unsorted .bam file.
+# ABOUT: Taxonomy is derived from `gtdb_to_ncbi_majority_vote.py` output
 # USAGE: navigate to the <examples> directory
-# USAGE: submg submit --config 05_reads_assembly_bins.yaml --staging_dir <path/to/staging/dir> --logging_dir <path/to/logging/dir> --submit_reads --submit_assembly --submit_bins
-
-
-STUDY: "PRJEB71644"                                                           # The accession of your study (which has to already exist in ENA) >>EXAMPLE: "PRJEB71644"
-METAGENOME_SCIENTIFIC_NAME: "biogas fermenter metagenome"                     # Taxonomic identifier of the metagenome. Check the ENA metagenome taxonomy tree to find a taxonomy ID and species name fitting your sample >>EXAMPLE: "biogas fermenter metagenome"
-METAGENOME_TAXID: "718289"                                                    # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
-SEQUENCING_PLATFORMS: ["ILLUMINA"]                                            # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
-SAMPLE_ACCESSIONS: ['SAMEA113417017', 'SAMEA113417018']                       # These samples exist in ENA. Your assembly is based on them. >>EXAMPLE: ["ERS15898933","ERS15898932"]
-PAIRED_END_READS:                                 
-- NAME: "3rIQA_ex05_rp1"                                                            # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
-  SEQUENCING_INSTRUMENT: "Illumina HiSeq 1500"                                # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
-  LIBRARY_SOURCE: "METAGENOMIC"                                               # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
-  LIBRARY_SELECTION: "RANDOM"                                                 # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
-  LIBRARY_STRATEGY: "WGS"                                                     # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
-  INSERT_SIZE: "300"                                                          # Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html) >>EXAMPLE: "300"
-  FASTQ1_FILE: "data/reads/fwd1.fastq"                                        # Path to the fastq file with forward reads >>EXAMPLE: "/mnt/data/reads_R1.fastq.gz"
-  FASTQ2_FILE: "data/reads/rev1.fastq"                                        # Path to the fastq file with reverse reads >>EXAMPLE: "/mnt/data/reads_R2.fastq.gz"
-  RELATED_SAMPLE_ACCESSION: 'SAMEA113417017'                                  # The accession of the sample that these reads originate from >>EXAMPLE: "ERS15898933"
-  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
-- NAME: "3rIQA_ex05_rp2"                                                            # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
-  SEQUENCING_INSTRUMENT: "Illumina HiSeq 1500"                                # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
-  LIBRARY_SOURCE: "METAGENOMIC"                                               # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
-  LIBRARY_SELECTION: "RANDOM"                                                 # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
-  LIBRARY_STRATEGY: "WGS"                                                     # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
-  INSERT_SIZE: "300"                                                          # Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html) >>EXAMPLE: "300"
-  FASTQ1_FILE: "data/reads/fwd2.fastq"                                        # Path to the fastq file with forward reads >>EXAMPLE: "/mnt/data/reads_R1.fastq.gz"
-  FASTQ2_FILE: "data/reads/rev2.fastq"                                        # Path to the fastq file with reverse reads >>EXAMPLE: "/mnt/data/reads_R2.fastq.gz"
-  RELATED_SAMPLE_ACCESSION: 'SAMEA113417018'                                  # The accession of the sample that these reads originate from >>EXAMPLE: "ERS15898933"
-  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
+# USAGE: submg submit --config 02_samples_reads_assembly_bins.yaml --staging_dir <path/to/staging/dir> --logging_dir <path/to/logging/dir> --submit_samples --submit_reads --submit_assembly --submit_bins
+  
+STUDY: "PRJEB71644"                                                                                   # The accession of your study (which has to already exist in ENA) >>EXAMPLE: "PRJEB71644"
+METAGENOME_SCIENTIFIC_NAME: 'ant fungus garden metagenome'                                            # Taxonomic identifier of the metagenome. Check the ENA metagenome taxonomy tree to find a taxonomy ID and species name fitting your sample >>EXAMPLE: "biogas fermenter metagenome"
+METAGENOME_TAXID: '797283'                                                                            # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
+SEQUENCING_PLATFORMS: ['ILLUMINA']                                                                    # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
+NEW_SAMPLES:                                                                                          # These samples will be created in ENA according to the data entered below. Your assembly MUST BE BASED ON ALL OF THESE.
+- TITLE: 'dlhr2_example02_sample01'                                                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
+  collection date: '2012'                                                                             # Any ISO compliant time. Can be truncated from the right (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
+  geographic location (country and/or sea): 'missing: data agreement established pre-2023'            # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
+SINGLE_READS:                                     
+- NAME: 'dlhr2_pe_reads_01_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+  SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
+  LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
+  LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
+  LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
+  FASTQ_FILE: "data/reads/fwd1.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
+  RELATED_SAMPLE_TITLE: 'dlhr2_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
+- NAME: 'dlhr2_pe_reads_02_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+  SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
+  LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
+  LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
+  LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
+  FASTQ_FILE: "data/reads/fwd2.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
+  RELATED_SAMPLE_TITLE: 'dlhr2_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
 ASSEMBLY:                                         
-  ASSEMBLY_NAME: "3rIQA_e05_coasm"                                       # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "SGMA project mg"
-  ASSEMBLY_SOFTWARE: "MEGAHIT"                                                # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
-  ISOLATION_SOURCE: "biogas plant anaerobic digester"                         # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
-  FASTA_FILE: "data/assembly.fasta"                                           # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"
-  collection date: "2024-01-01"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
-  geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
-  COVERAGE_VALUE: 128.27                                                      # Read coverage of the assembly.
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
+  ASSEMBLY_NAME: 'dlhr2_e02_asm'                                                                 # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
+  ASSEMBLY_SOFTWARE: 'metaSPAdes'                                                                     # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
+  ISOLATION_SOURCE: 'ant fungus garden'                                                               # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
+  FASTA_FILE: "data/assembly.fasta"                                                                   # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"
+  collection date: '2012-02'                                                                          # Any ISO compliant time. Can be truncated from the right (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
+  geographic location (country and/or sea): 'missing: data agreement established pre-2023'            # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
+  ADDITIONAL_SAMPLESHEET_FIELDS:
+    geographic location (latitude): 52.51                                                             # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
+    geographic location (longitude): 8.77                                                             # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
+  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
 BINS:                                             
-  BINS_DIRECTORY: "data/3bins"                                                # Directory containing the fasta files of all bins/MAGs >>EXAMPLE: "/mnt/data/bins"
-  COMPLETENESS_SOFTWARE: "CheckM"                                             # Software used to calculate completeness >>EXAMPLE: "CheckM"
-  QUALITY_FILE: "data/checkm_quality_3bins.tsv"                               # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
-  NCBI_TAXONOMY_FILES:                                                        # A list of files with NCBI taxonomy information about the bins. Consult the README to see how they should be structured. >>EXAMPLE: ["/mnt/data/bacteria_tax.tsv","/mnt/data/archaea_tax.tsv"]
-  - "data/taxonomy/archaea_taxonomy.tsv"
-  - "data/taxonomy/bacteria_taxonomy.tsv"
-  MANUAL_TAXONOMY_FILE: "data/taxonomy/manual_taxonomy.tsv"                   # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
-  BINNING_SOFTWARE: "metabat2"                                                # The program that was used for binning. >>EXAMPLE: "metabat2"
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
-  COVERAGE_FILE: "data/bin_coverage.tsv"                                      # .tsv file containing the coverage values of each bin. Columns must be 'Bin_id' and 'Coverage'.
-                                                  
+  BINS_DIRECTORY: "data/3bins"                                                                        # Directory containing the fasta files of all bins/MAGs >>EXAMPLE: "/mnt/data/bins"
+  COMPLETENESS_SOFTWARE: "CheckM"                             
+  NCBI_TAXONOMY_FILES: "taxotest/archaea_taxonomy.tsv"                                        # Software used to calculate completeness >>EXAMPLE: "CheckM"
+  QUALITY_FILE: "taxotest/checkm_quality_3bins.tsv"                                                       # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
+  MANUAL_TAXONOMY_FILE: "taxotest/manual_taxonomy_3bins.tsv"                                                                              # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
+  BINNING_SOFTWARE: 'VAMB'         
+  MIN_COMPLETENESS: 1                                                        # Bins with smaller completeness value will be discarded (values in percent, 0-100). Remove this row to ignore bin completeness. >>EXAMPLE: "90"
+  MAX_CONTAMINATION: 100                                                       # Bins with larger contamination value will be discarded (values in percent, 0-100). Remove this row to ignore bin contamination (>100% contamination bins will still be discarded). >>EXAMPLE: "5"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
+  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
+BAM_FILES:
+  - "data/mapping/1.unsorted.bam"                                                  

--- a/examples/localtest.yaml
+++ b/examples/localtest.yaml
@@ -1,55 +1,85 @@
-# ABOUT: This is a config for submitting 1 sample, 2 sets of single-end reads, an assembly and bins.
-# ABOUT: Coverage is derived from one unsorted .bam file.
-# ABOUT: Taxonomy is derived from `gtdb_to_ncbi_majority_vote.py` output
+# ABOUT: This a config for submitting samples, paired-end reads, an assembly, bins and MAGs
+# ABOUT: Coverage is derived from 2 bam files.
+# ABOUT: Taxonomy is derived from `gtdb_to_ncbi_majority_vote.py` output and a MANUAL_TAXONOMY_FILE
 # USAGE: navigate to the <examples> directory
-# USAGE: submg submit --config 02_samples_reads_assembly_bins.yaml --staging_dir <path/to/staging/dir> --logging_dir <path/to/logging/dir> --submit_samples --submit_reads --submit_assembly --submit_bins
-  
-STUDY: "PRJEB71644"                                                                                   # The accession of your study (which has to already exist in ENA) >>EXAMPLE: "PRJEB71644"
-METAGENOME_SCIENTIFIC_NAME: 'ant fungus garden metagenome'                                            # Taxonomic identifier of the metagenome. Check the ENA metagenome taxonomy tree to find a taxonomy ID and species name fitting your sample >>EXAMPLE: "biogas fermenter metagenome"
-METAGENOME_TAXID: '797283'                                                                            # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
-SEQUENCING_PLATFORMS: ['ILLUMINA']                                                                    # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
-NEW_SAMPLES:                                                                                          # These samples will be created in ENA according to the data entered below. Your assembly MUST BE BASED ON ALL OF THESE.
-- TITLE: 'rv7ck_example02_sample01'                                                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
-  collection date: '2012'                                                                             # Any ISO compliant time. Can be truncated from the right (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
-  geographic location (country and/or sea): 'missing: data agreement established pre-2023'            # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
-SINGLE_READS:                                     
-- NAME: 'rv7ck_pe_reads_01_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
-  SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
-  LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
-  LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
-  LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
-  FASTQ_FILE: "data/reads/fwd1.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
-  RELATED_SAMPLE_TITLE: 'rv7ck_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
-  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
-- NAME: 'rv7ck_pe_reads_02_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
-  SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
-  LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
-  LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
-  LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
-  FASTQ_FILE: "data/reads/fwd2.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
-  RELATED_SAMPLE_TITLE: 'rv7ck_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
-  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
+# USAGE: submg submit --config 01_samples_reads_assembly_bins_mags.yaml --staging_dir <path/to/staging/dir> --logging_dir <path/to/logging/dir> --submit_samples --submit_reads --submit_assembly --submit_bins --submit_mags
+
+STUDY: "PRJEB71644"                                                           # The accession of your study (which has to already exist in ENA) >>EXAMPLE: "PRJEB71644"
+METAGENOME_SCIENTIFIC_NAME: "biogas fermenter metagenome"                     # Taxonomic identifier of the metagenome. Check the ENA metagenome taxonomy tree to find a taxonomy ID and species name fitting your sample >>EXAMPLE: "biogas fermenter metagenome"
+METAGENOME_TAXID: "718289"                                                    # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
+SEQUENCING_PLATFORMS: ["ILLUMINA"]                                            # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
+PROJECT_NAME: "7yyIc_AgRFex 2 Survey"                                         # Name of the project within which the sequencing was organized >>EXAMPLE: "AgRFex 2 Biogas Survey"
+NEW_SAMPLES:                                                                  # These samples will be created in ENA according to the data entered below. Your assembly MUST BE BASED ON ALL OF THESE.
+- TITLE: "7yyIc_hydrolysis digester sample"                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
+  collection date: "2022-07-12"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
+  geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
+    geographic location (latitude): 52.51                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
+    geographic location (longitude): 8.77                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
+    broad-scale environmental context: "tropical biome"                       # For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical biome"
+    local environmental context: "tropical marine upwelling biome"            # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical marine upwelling biome"
+    environmental medium: "grass silage|animal waste material|anoxic water"   # Pipe separated! For more information consult an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) and https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS >>EXAMPLE: "grass silage|animal waste material|anoxic water"
+- TITLE: "7yyIc_main digester sample"                                         # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
+  collection date: "2022-07-12"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
+  geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
+    geographic location (latitude): 52.51                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
+    geographic location (longitude): 8.77                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
+    broad-scale environmental context: "tropical biome"                       # For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical biome"
+    local environmental context: "tropical marine upwelling biome"            # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical marine upwelling biome"
+    environmental medium: "grass silage|animal waste material|anoxic water"   # Pipe separated! For more information consult an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) and https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS >>EXAMPLE: "grass silage|animal waste material|anoxic water"
+PAIRED_END_READS:                                 
+- NAME: "7yyIc_dh_pe"                                                         # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+  SEQUENCING_INSTRUMENT: "Illumina HiSeq 1500"                                # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
+  LIBRARY_SOURCE: "METAGENOMIC"                                               # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
+  LIBRARY_SELECTION: "RANDOM"                                                 # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
+  LIBRARY_STRATEGY: "WGS"                                                     # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
+  INSERT_SIZE: "300"                                                          # Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html) >>EXAMPLE: "300"
+  FASTQ1_FILE: "data/reads/fwd1.fastq"                                        # Path to the fastq file with forward reads >>EXAMPLE: "/mnt/data/reads_R1.fastq.gz"
+  FASTQ2_FILE: "data/reads/rev1.fastq"                                        # Path to the fastq file with reverse reads >>EXAMPLE: "/mnt/data/reads_R2.fastq.gz"
+  RELATED_SAMPLE_TITLE: "7yyIc_hydrolysis digester sample"                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
+- NAME: "7yyIc_dm_pe"                                                         # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+  SEQUENCING_INSTRUMENT: "Illumina HiSeq 1500"                                # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
+  LIBRARY_SOURCE: "GENOMIC"                                                   # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
+  LIBRARY_SELECTION: "RANDOM"                                                 # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
+  LIBRARY_STRATEGY: "WGS"                                                     # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
+  INSERT_SIZE: "300"                                                          # Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html) >>EXAMPLE: "300"
+  FASTQ1_FILE: "data/reads/fwd2.fastq"                                        # Path to the fastq file with forward reads >>EXAMPLE: "/mnt/data/reads_R1.fastq.gz"
+  FASTQ2_FILE: "data/reads/rev2.fastq"                                        # Path to the fastq file with reverse reads >>EXAMPLE: "/mnt/data/reads_R2.fastq.gz"
+  RELATED_SAMPLE_TITLE: "7yyIc_main digester sample"                          # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
 ASSEMBLY:                                         
-  ASSEMBLY_NAME: 'rv7ck_e02_asm'                                                                 # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
-  ASSEMBLY_SOFTWARE: 'metaSPAdes'                                                                     # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
-  ISOLATION_SOURCE: 'ant fungus garden'                                                               # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
-  FASTA_FILE: "data/assembly.fasta"                                                                   # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"
-  collection date: '2012-02'                                                                          # Any ISO compliant time. Can be truncated from the right (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
-  geographic location (country and/or sea): 'missing: data agreement established pre-2023'            # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
-  ADDITIONAL_SAMPLESHEET_FIELDS:
-    geographic location (latitude): 52.51                                                             # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
-    geographic location (longitude): 8.77                                                             # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
-  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
+  ASSEMBLY_NAME: "7yyIc_e01_coasm"                                       # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "SGMA project mg"
+  ASSEMBLY_SOFTWARE: "MEGAHIT"                                                # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
+  ISOLATION_SOURCE: "biogas plant anaerobic digester"                         # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
+  FASTA_FILE: "data/assembly.fasta"                                           # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"
+  collection date: "2022-07-12"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
+  geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
+    geographic location (latitude): 52.51                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
+    geographic location (longitude): 8.77                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
+    broad-scale environmental context: "tropical biome"                       # For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical biome"
+    local environmental context: "tropical marine upwelling biome"            # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical marine upwelling biome"
+    environmental medium: "grass silage|animal waste material|anoxic water"   # Pipe separated! For more information consult an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) and https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS >>EXAMPLE: "grass silage|animal waste material|anoxic water"
+  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
 BINS:                                             
-  BINS_DIRECTORY: "data/3bins"                                                                        # Directory containing the fasta files of all bins/MAGs >>EXAMPLE: "/mnt/data/bins"
-  COMPLETENESS_SOFTWARE: "CheckM"                             
-  NCBI_TAXONOMY_FILES: ["taxotest/archaea_taxonomy.tsv", "taxotest/bacteria_taxonomy.tsv"]                                        # Software used to calculate completeness >>EXAMPLE: "CheckM"
-  QUALITY_FILE: "taxotest/checkm_quality_3bins.tsv"                                                       # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
-  BINNING_SOFTWARE: 'VAMB'         
-  MIN_COMPLETENESS: 1                                                        # Bins with smaller completeness value will be discarded (values in percent, 0-100). Remove this row to ignore bin completeness. >>EXAMPLE: "90"
-  MAX_CONTAMINATION: 100                                                       # Bins with larger contamination value will be discarded (values in percent, 0-100). Remove this row to ignore bin contamination (>100% contamination bins will still be discarded). >>EXAMPLE: "5"
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
-  ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
-BAM_FILES:
-  - "data/mapping/1.unsorted.bam"                                                  
+  BINS_DIRECTORY: "data/3bins"                                                # Directory containing the fasta files of all bins/MAGs >>EXAMPLE: "/mnt/data/bins"
+  COMPLETENESS_SOFTWARE: "CheckM"                                             # Software used to calculate completeness >>EXAMPLE: "CheckM"
+  QUALITY_FILE: "data/checkm_quality_3bins.tsv"                               # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
+  NCBI_TAXONOMY_FILES:                                                        # A list of files with NCBI taxonomy information about the bins. Consult the README to see how they should be structured. >>EXAMPLE: ["/mnt/data/bacteria_tax.tsv","/mnt/data/archaea_tax.tsv"]
+  - "data/taxonomy/archaea_taxonomy.tsv"
+  - "data/taxonomy/bacteria_taxonomy.tsv"                              
+  MANUAL_TAXONOMY_FILE: "data/taxonomy/manual_taxonomy.tsv"                   # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
+  BINNING_SOFTWARE: "metabat2"                                                # The program that was used for binning. >>EXAMPLE: "metabat2"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
+    binning parameters: "default"                                             # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000047) >>EXAMPLE: "default"
+    taxonomic identity marker: "multi marker approach"                        # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000047) >>EXAMPLE: "multi marker approach"
+  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
+MAGS:                                             
+  MAG_METADATA_FILE: "data/mag_metadata/mag_metadata.tsv"                     # A .tsv specifying 'Bin_id', 'Sample_id', 'Quality_category', 'Flatfile_path' and 'Unlocalised_path' for all MAGs. See README for more details. >>EXAMPLE: "/mnt/data/mag_data.tsv"
+  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
+  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
+BAM_FILES:                                                                    # The reads from your experiment mapped back to the assembly
+  - "data/mapping/1.sorted.bam"
+  - "data/mapping/2.sorted.bam"

--- a/examples/localtest.yaml
+++ b/examples/localtest.yaml
@@ -1,35 +1,17 @@
-# ABOUT: This a config for submitting samples, paired-end reads, an assembly, bins and MAGs
-# ABOUT: Coverage is derived from 2 bam files.
+# ABOUT: This is a config for submitting 2 set of paired end reads, an assembly and bins
+# ABOUT: Coverage is known.
 # ABOUT: Taxonomy is derived from `gtdb_to_ncbi_majority_vote.py` output and a MANUAL_TAXONOMY_FILE
 # USAGE: navigate to the <examples> directory
-# USAGE: submg submit --config 01_samples_reads_assembly_bins_mags.yaml --staging_dir <path/to/staging/dir> --logging_dir <path/to/logging/dir> --submit_samples --submit_reads --submit_assembly --submit_bins --submit_mags
+# USAGE: submg submit --config 05_reads_assembly_bins.yaml --staging_dir <path/to/staging/dir> --logging_dir <path/to/logging/dir> --submit_reads --submit_assembly --submit_bins
+
 
 STUDY: "PRJEB71644"                                                           # The accession of your study (which has to already exist in ENA) >>EXAMPLE: "PRJEB71644"
 METAGENOME_SCIENTIFIC_NAME: "biogas fermenter metagenome"                     # Taxonomic identifier of the metagenome. Check the ENA metagenome taxonomy tree to find a taxonomy ID and species name fitting your sample >>EXAMPLE: "biogas fermenter metagenome"
 METAGENOME_TAXID: "718289"                                                    # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
 SEQUENCING_PLATFORMS: ["ILLUMINA"]                                            # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
-PROJECT_NAME: "7yyIc_AgRFex 2 Survey"                                         # Name of the project within which the sequencing was organized >>EXAMPLE: "AgRFex 2 Biogas Survey"
-NEW_SAMPLES:                                                                  # These samples will be created in ENA according to the data entered below. Your assembly MUST BE BASED ON ALL OF THESE.
-- TITLE: "7yyIc_hydrolysis digester sample"                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
-  collection date: "2022-07-12"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
-  geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-    geographic location (latitude): 52.51                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
-    geographic location (longitude): 8.77                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
-    broad-scale environmental context: "tropical biome"                       # For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical biome"
-    local environmental context: "tropical marine upwelling biome"            # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical marine upwelling biome"
-    environmental medium: "grass silage|animal waste material|anoxic water"   # Pipe separated! For more information consult an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) and https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS >>EXAMPLE: "grass silage|animal waste material|anoxic water"
-- TITLE: "7yyIc_main digester sample"                                         # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
-  collection date: "2022-07-12"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
-  geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-    geographic location (latitude): 52.51                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
-    geographic location (longitude): 8.77                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
-    broad-scale environmental context: "tropical biome"                       # For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical biome"
-    local environmental context: "tropical marine upwelling biome"            # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical marine upwelling biome"
-    environmental medium: "grass silage|animal waste material|anoxic water"   # Pipe separated! For more information consult an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) and https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS >>EXAMPLE: "grass silage|animal waste material|anoxic water"
+SAMPLE_ACCESSIONS: ['SAMEA113417017', 'SAMEA113417018']                       # These samples exist in ENA. Your assembly is based on them. >>EXAMPLE: ["ERS15898933","ERS15898932"]
 PAIRED_END_READS:                                 
-- NAME: "7yyIc_dh_pe"                                                         # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+- NAME: "AKQ4G_ex05_rp1"                                                            # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
   SEQUENCING_INSTRUMENT: "Illumina HiSeq 1500"                                # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
   LIBRARY_SOURCE: "METAGENOMIC"                                               # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
   LIBRARY_SELECTION: "RANDOM"                                                 # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
@@ -37,31 +19,27 @@ PAIRED_END_READS:
   INSERT_SIZE: "300"                                                          # Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html) >>EXAMPLE: "300"
   FASTQ1_FILE: "data/reads/fwd1.fastq"                                        # Path to the fastq file with forward reads >>EXAMPLE: "/mnt/data/reads_R1.fastq.gz"
   FASTQ2_FILE: "data/reads/rev1.fastq"                                        # Path to the fastq file with reverse reads >>EXAMPLE: "/mnt/data/reads_R2.fastq.gz"
-  RELATED_SAMPLE_TITLE: "7yyIc_hydrolysis digester sample"                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  RELATED_SAMPLE_ACCESSION: 'SAMEA113417017'                                  # The accession of the sample that these reads originate from >>EXAMPLE: "ERS15898933"
   ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
-- NAME: "7yyIc_dm_pe"                                                         # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+- NAME: "AKQ4G_ex05_rp2"                                                            # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
   SEQUENCING_INSTRUMENT: "Illumina HiSeq 1500"                                # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
-  LIBRARY_SOURCE: "GENOMIC"                                                   # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
+  LIBRARY_SOURCE: "METAGENOMIC"                                               # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
   LIBRARY_SELECTION: "RANDOM"                                                 # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
   LIBRARY_STRATEGY: "WGS"                                                     # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
   INSERT_SIZE: "300"                                                          # Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html) >>EXAMPLE: "300"
   FASTQ1_FILE: "data/reads/fwd2.fastq"                                        # Path to the fastq file with forward reads >>EXAMPLE: "/mnt/data/reads_R1.fastq.gz"
   FASTQ2_FILE: "data/reads/rev2.fastq"                                        # Path to the fastq file with reverse reads >>EXAMPLE: "/mnt/data/reads_R2.fastq.gz"
-  RELATED_SAMPLE_TITLE: "7yyIc_main digester sample"                          # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  RELATED_SAMPLE_ACCESSION: 'SAMEA113417018'                                  # The accession of the sample that these reads originate from >>EXAMPLE: "ERS15898933"
   ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
 ASSEMBLY:                                         
-  ASSEMBLY_NAME: "7yyIc_e01_coasm"                                       # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "SGMA project mg"
+  ASSEMBLY_NAME: "AKQ4G_e05_coasm"                                       # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "SGMA project mg"
   ASSEMBLY_SOFTWARE: "MEGAHIT"                                                # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
   ISOLATION_SOURCE: "biogas plant anaerobic digester"                         # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
   FASTA_FILE: "data/assembly.fasta"                                           # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"
-  collection date: "2022-07-12"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
+  collection date: "2024-01-01"                                               # Any ISO compliant time. Can be truncated from the righ (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
   geographic location (country and/or sea): "Germany"                         # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
+  COVERAGE_VALUE: 128.27                                                      # Read coverage of the assembly.
   ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-    geographic location (latitude): 52.51                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "41.85"
-    geographic location (longitude): 8.77                                     # Use WGS84. For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "-87.65"
-    broad-scale environmental context: "tropical biome"                       # For more information consult appropriate an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical biome"
-    local environmental context: "tropical marine upwelling biome"            # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) >>EXAMPLE: "tropical marine upwelling biome"
-    environmental medium: "grass silage|animal waste material|anoxic water"   # Pipe separated! For more information consult an ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000050) and https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS >>EXAMPLE: "grass silage|animal waste material|anoxic water"
   ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
 BINS:                                             
   BINS_DIRECTORY: "data/3bins"                                                # Directory containing the fasta files of all bins/MAGs >>EXAMPLE: "/mnt/data/bins"
@@ -69,17 +47,10 @@ BINS:
   QUALITY_FILE: "data/checkm_quality_3bins.tsv"                               # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
   NCBI_TAXONOMY_FILES:                                                        # A list of files with NCBI taxonomy information about the bins. Consult the README to see how they should be structured. >>EXAMPLE: ["/mnt/data/bacteria_tax.tsv","/mnt/data/archaea_tax.tsv"]
   - "data/taxonomy/archaea_taxonomy.tsv"
-  - "data/taxonomy/bacteria_taxonomy.tsv"                              
+  - "data/taxonomy/bacteria_taxonomy.tsv"
   MANUAL_TAXONOMY_FILE: "data/taxonomy/manual_taxonomy.tsv"                   # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
   BINNING_SOFTWARE: "metabat2"                                                # The program that was used for binning. >>EXAMPLE: "metabat2"
   ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-    binning parameters: "default"                                             # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000047) >>EXAMPLE: "default"
-    taxonomic identity marker: "multi marker approach"                        # For more information consult an appropriate ENA samplesheet template (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000047) >>EXAMPLE: "multi marker approach"
   ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
-MAGS:                                             
-  MAG_METADATA_FILE: "data/mag_metadata/mag_metadata.tsv"                     # A .tsv specifying 'Bin_id', 'Sample_id', 'Quality_category', 'Flatfile_path' and 'Unlocalised_path' for all MAGs. See README for more details. >>EXAMPLE: "/mnt/data/mag_data.tsv"
-  ADDITIONAL_SAMPLESHEET_FIELDS:                                              # Please add more fields from the ENA samplesheet that most closely matches your experiment
-  ADDITIONAL_MANIFEST_FIELDS:                                                 # You can add additional fields that will be written to the manifest
-BAM_FILES:                                                                    # The reads from your experiment mapped back to the assembly
-  - "data/mapping/1.sorted.bam"
-  - "data/mapping/2.sorted.bam"
+  COVERAGE_FILE: "data/bin_coverage.tsv"                                      # .tsv file containing the coverage values of each bin. Columns must be 'Bin_id' and 'Coverage'.
+                                                  

--- a/examples/localtest.yaml
+++ b/examples/localtest.yaml
@@ -9,29 +9,29 @@ METAGENOME_SCIENTIFIC_NAME: 'ant fungus garden metagenome'                      
 METAGENOME_TAXID: '797283'                                                                            # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
 SEQUENCING_PLATFORMS: ['ILLUMINA']                                                                    # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
 NEW_SAMPLES:                                                                                          # These samples will be created in ENA according to the data entered below. Your assembly MUST BE BASED ON ALL OF THESE.
-- TITLE: '4YzFv_example02_sample01'                                                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
+- TITLE: 'rv7ck_example02_sample01'                                                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
   collection date: '2012'                                                                             # Any ISO compliant time. Can be truncated from the right (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
   geographic location (country and/or sea): 'missing: data agreement established pre-2023'            # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
   ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
 SINGLE_READS:                                     
-- NAME: '4YzFv_pe_reads_01_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+- NAME: 'rv7ck_pe_reads_01_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
   SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
   LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
   LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
   LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
   FASTQ_FILE: "data/reads/fwd1.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
-  RELATED_SAMPLE_TITLE: '4YzFv_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  RELATED_SAMPLE_TITLE: 'rv7ck_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
   ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
-- NAME: '4YzFv_pe_reads_02_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+- NAME: 'rv7ck_pe_reads_02_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
   SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
   LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
   LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
   LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
   FASTQ_FILE: "data/reads/fwd2.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
-  RELATED_SAMPLE_TITLE: '4YzFv_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  RELATED_SAMPLE_TITLE: 'rv7ck_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
   ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
 ASSEMBLY:                                         
-  ASSEMBLY_NAME: '4YzFv_e02_asm'                                                                 # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
+  ASSEMBLY_NAME: 'rv7ck_e02_asm'                                                                 # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
   ASSEMBLY_SOFTWARE: 'metaSPAdes'                                                                     # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
   ISOLATION_SOURCE: 'ant fungus garden'                                                               # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
   FASTA_FILE: "data/assembly.fasta"                                                                   # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"
@@ -44,9 +44,8 @@ ASSEMBLY:
 BINS:                                             
   BINS_DIRECTORY: "data/3bins"                                                                        # Directory containing the fasta files of all bins/MAGs >>EXAMPLE: "/mnt/data/bins"
   COMPLETENESS_SOFTWARE: "CheckM"                             
-  NCBI_TAXONOMY_FILES: "taxotest/archaea_taxonomy.tsv"                                        # Software used to calculate completeness >>EXAMPLE: "CheckM"
+  NCBI_TAXONOMY_FILES: ["taxotest/archaea_taxonomy.tsv", "taxotest/bacteria_taxonomy.tsv"]                                        # Software used to calculate completeness >>EXAMPLE: "CheckM"
   QUALITY_FILE: "taxotest/checkm_quality_3bins.tsv"                                                       # tsv file containing quality values of each bin. Header must include 'Bin_id', 'Completeness', 'Contamination'. A CheckM output table will work here. >>EXAMPLE: "/mnt/data/checkm_quality.tsv"
-  MANUAL_TAXONOMY_FILE: "taxotest/manual_taxonomy_3bins.tsv"                                                                              # Scientific names and taxids for bins. See example file for the structure. Columns must be 'Bin_id', 'Tax_id' and 'Scientific_name'. Consult the README for more information. >>EXAMPLE: "/mnt/data/manual_tax.tsv"
   BINNING_SOFTWARE: 'VAMB'         
   MIN_COMPLETENESS: 1                                                        # Bins with smaller completeness value will be discarded (values in percent, 0-100). Remove this row to ignore bin completeness. >>EXAMPLE: "90"
   MAX_CONTAMINATION: 100                                                       # Bins with larger contamination value will be discarded (values in percent, 0-100). Remove this row to ignore bin contamination (>100% contamination bins will still be discarded). >>EXAMPLE: "5"

--- a/examples/localtest.yaml
+++ b/examples/localtest.yaml
@@ -9,29 +9,29 @@ METAGENOME_SCIENTIFIC_NAME: 'ant fungus garden metagenome'                      
 METAGENOME_TAXID: '797283'                                                                            # Taxonomic identifier of the assembly. Must match SPECIES_SCIENTIFIC_NAME >>EXAMPLE: "718289"
 SEQUENCING_PLATFORMS: ['ILLUMINA']                                                                    # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#platform >>EXAMPLE: ["ILLUMINA","OXFORD_NANOPORE"]
 NEW_SAMPLES:                                                                                          # These samples will be created in ENA according to the data entered below. Your assembly MUST BE BASED ON ALL OF THESE.
-- TITLE: 'dlhr2_example02_sample01'                                                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
+- TITLE: '4YzFv_example02_sample01'                                                                   # A unique title for your sample >>EXAMPLE: "Bioreactor_2_sample"
   collection date: '2012'                                                                             # Any ISO compliant time. Can be truncated from the right (e.g. '2023-12-27T16:07' or '2023-12') >>EXAMPLE: "2023-03"
   geographic location (country and/or sea): 'missing: data agreement established pre-2023'            # See ENA checklists (e.g. https://www.ebi.ac.uk/ena/browser/view/ERC000011) for valid values >>EXAMPLE: "Germany"
   ADDITIONAL_SAMPLESHEET_FIELDS:                                                                      # Please add more fields from the ENA samplesheet that most closely matches your experiment
 SINGLE_READS:                                     
-- NAME: 'dlhr2_pe_reads_01_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+- NAME: '4YzFv_pe_reads_01_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
   SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
   LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
   LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
   LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
   FASTQ_FILE: "data/reads/fwd1.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
-  RELATED_SAMPLE_TITLE: 'dlhr2_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  RELATED_SAMPLE_TITLE: '4YzFv_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
   ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
-- NAME: 'dlhr2_pe_reads_02_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
+- NAME: '4YzFv_pe_reads_02_sample01'                                                                  # Choose a unique name >>EXAMPLE: "Bioreactor_2_replicate_1"
   SEQUENCING_INSTRUMENT: 'Illumina MiSeq'                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#instrument >>EXAMPLE: ["Illumina HiSeq 1500", "GridION"]
   LIBRARY_SOURCE: 'METAGENOMIC'                                                                       # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "GENOMIC"
   LIBRARY_SELECTION: 'RANDOM'                                                                         # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-source >>EXAMPLE: "RANDOM"
   LIBRARY_STRATEGY: 'WGS'                                                                             # One of https://ena-docs.readthedocs.io/en/latest/submit/reads/webin-cli.html#permitted-values-for-library-strategy >>EXAMPLE: "WGS"
   FASTQ_FILE: "data/reads/fwd2.fastq"                                                                 # Path to the fastq file >>EXAMPLE: "/mnt/data/reads.fastq.gz"
-  RELATED_SAMPLE_TITLE: 'dlhr2_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
+  RELATED_SAMPLE_TITLE: '4YzFv_example02_sample01'                                                    # The title of the sample that these reads originate from >>EXAMPLE: "Bioreactor_2_sample"
   ADDITIONAL_MANIFEST_FIELDS:                                                                         # You can add additional fields that will be written to the manifest
 ASSEMBLY:                                         
-  ASSEMBLY_NAME: 'dlhr2_e02_asm'                                                                 # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
+  ASSEMBLY_NAME: '4YzFv_e02_asm'                                                                 # Choose a name, even if your assembly has been uploaded already. Will only be used for naming assembly and bins/MAGs. >>EXAMPLE: "Northern Germany biogas digester metagenome"
   ASSEMBLY_SOFTWARE: 'metaSPAdes'                                                                     # Software used to generate the assembly >>EXAMPLE: "MEGAHIT"
   ISOLATION_SOURCE: 'ant fungus garden'                                                               # Describe where your sample was taken from >>EXAMPLE: "biogas plant anaerobic digester"
   FASTA_FILE: "data/assembly.fasta"                                                                   # Path to the fasta file >>EXAMPLE: "/mnt/data/assembly.fasta.gz"

--- a/submg/enaSearching.py
+++ b/submg/enaSearching.py
@@ -189,8 +189,6 @@ def search_samples_by_assembly_analysis(assembly_analysis_accession: str,
         "fields": "sample_accession"
     }
     response = requests.get(url, params=params)
-    print("INPUT: ", assembly_analysis_accession)
-    print("RESPONSE: ", response.text)
 
     try:
         sample_accession = response.text.split('\n')[1:-1][0]
@@ -242,6 +240,7 @@ def search_scientific_name_by_sample(sample_accession: str,
 
 if __name__ == "__main__":
     # For debugging
+    print("DEBUG: Checking API availability...\n")
     print("DEBUG: Running sample_accession_exists('SAMEA113417025',False)")
     print(sample_accession_exists('SAMEA113417025',False))
     print("DEBUG: Running sample_accession_exists('ERS28162653', False)")

--- a/submg/magSubmission.py
+++ b/submg/magSubmission.py
@@ -399,11 +399,12 @@ def submit_mags(config: dict,
     bin_files = binSubmission.get_bins_in_dir(bins_directory)
     if not depth_files is None:
         bin_coverages = binSubmission.bin_coverage_from_depth(depth_files,
-                                                bin_files,
-                                                threads=threads)
+                                                              bin_files,
+                                                              threads=threads)
     elif not bin_coverage_file is None:
-        bin_coverages = binSubmission.bin_coverage_from_tsv(bin_coverage_file,
-                                              bin_files)
+        bin_coverages = binSubmission.bin_coverage_from_tsv(mag_metadata.keys(),
+                                                            bin_coverage_file,
+                                                            bin_files)
         
     # Make a samplesheet for all MAGs
     loggingC.message(">Making MAG samplesheet", threshold=1)

--- a/submg/main.py
+++ b/submg/main.py
@@ -1,13 +1,17 @@
-#!/usr/bin/env python
-
 import argparse
 import os
 import time
 import traceback
 
-from submg import loggingC, utility, preflight, configGen, webinDownload, enaSearching, taxQuery
-from submg.statConf import staticConfig
+from submg import loggingC
+from submg import preflight
+from submg import utility
+from submg import webinDownload
+from submg import configGen 
+from submg import taxQuery
+from submg import enaSearching
 
+from submg.statConf import staticConfig
 from submg.utility import prepdir
 from submg.sampleSubmission import submit_samples
 from submg.readSubmission import submit_reads
@@ -16,8 +20,14 @@ from submg.binSubmission import submit_bins, get_bin_quality
 from submg.magSubmission import submit_mags
 
 
-def main():
-    # Parsing command line input
+def init_argparse():
+    """
+    Use argparse to parse command line arguments and return the arguments
+    object.
+
+    Returns:
+        argparse.ArgumentParser: The arguments object.
+    """
     parser = argparse.ArgumentParser(description="""Tool for submitting metagenome bins to the European Nucleotide Archive.
                                      Environment variables ENA_USER and ENA_PASSWORD must be set for ENA upload.""")
     parser.add_argument("-v", "--version",          action="version", version=f"%(prog)s {staticConfig.submg_version}")
@@ -165,6 +175,12 @@ def main():
                                 help="Use if you want to submit one assembly. "
                                 "To submit multiple assemblies, you need to "
                                 "use the tool multiple times.")
+    parser_makecfg.add_argument("-q",
+                                "--quality_cutoffs",
+                                action="store_true",
+                                default=False,
+                                help="Include fields for bin quality cutoff "
+                                "(contamination & completeness) in config.")
 
     coverage_group = parser_makecfg.add_mutually_exclusive_group(required=True)
     coverage_group.add_argument("--coverage_from_bam",
@@ -176,231 +192,253 @@ def main():
                                 help="Coverages are already known and you "
                                 "provide them as a .bam file.")
 
-    args = parser.parse_args()
-
-    # Webin-cli download
-    if args.mode == 'download_webin':
-        toolVersion, webinCliVersion = webinDownload.versions()
-        print(f">Versions: tool={toolVersion}, webin-cli={webinCliVersion}")
-        print(">Checking Java installation...")
-        webinDownload.check_java()
-        webinDownload.download_webin_cli(webinCliVersion)
-
-    # Config generation
-    elif args.mode == 'makecfg':
-        configGen.make_config(outpath=args.outfile,
-                              submit_samples=args.submit_samples,
-                              submit_single_reads=args.submit_single_reads,
-                              submit_paired_end_reads=args.submit_paired_end_reads,
-                              coverage_from_bam=args.coverage_from_bam,
-                              known_coverage=args.known_coverage,
-                              submit_assembly=args.submit_assembly,
-                              submit_bins=args.submit_bins,
-                              submit_mags=args.submit_mags,
-                              no_comments=args.no_comments)
+    return parser
 
 
-    # Submission
-    elif args.mode == 'submit':
+def download_webin():
+    """
+    Download the webin-cli .jar file.
+    """
+    toolVersion, webinCliVersion = webinDownload.versions()
+    print(f">Versions: tool={toolVersion}, webin-cli={webinCliVersion}")
+    print(">Checking Java installation...")
+    webinDownload.check_java()
+    webinDownload.download_webin_cli(webinCliVersion)
 
-        loggingC.set_up_logging(args.logging_dir, args.verbosity)
-        if args.timestamps or (args.timestamps is None and args.development_service):
-            utility.set_up_timestamps(vars(args))
 
-        try:        
-            sver = staticConfig.submg_version
-            wver = staticConfig.webin_cli_version
-            loggingC.message(f">Running submg {sver} with webin-cli {wver}", 0)
-            if args.development_service == 1:
-                loggingC.message((">Initializing a test submission to " \
-                                   "the ENA dev server."), 0)
-            else:
-                loggingC.message((">Initializing a LIVE SUBMISSION to " \
-                                   "the ENA production server."), 0)
-                time.sleep(5)
+def makecfg(args):
+    """
+    Use configGen to create a .yml file containing the fields a user needs
+    to fill in order to create a submission for their specific setup
+    """
+    configGen.make_config(outpath=args.outfile,
+                          submit_samples=args.submit_samples,
+                          submit_single_reads=args.submit_single_reads,
+                          submit_paired_end_reads=args.submit_paired_end_reads,
+                          coverage_from_bam=args.coverage_from_bam,
+                          known_coverage=args.known_coverage,
+                          submit_assembly=args.submit_assembly,
+                          submit_bins=args.submit_bins,
+                          submit_mags=args.submit_mags,
+                          no_comments=args.no_comments,
+                          quality_cutoffs=args.quality_cutoffs)
+    
 
-            if not args.skip_checks:
-                utility.validate_parameter_combination(args.submit_samples,
-                                                       args.submit_reads,
-                                                       args.submit_assembly,
-                                                       args.submit_bins,
-                                                       args.submit_mags)
+def submit(args):
+    """
+    Submit data to the ENA.
 
-            config = preflight.preflight_checks(vars(args))
+    Args:
+        args (argparse.Namespace): The arguments object.
+    """
+    loggingC.set_up_logging(args.logging_dir, args.verbosity)
+    if args.timestamps or (args.timestamps is None and args.development_service):
+        utility.set_up_timestamps(vars(args))
 
-            # If we are submitting bins, get the quality scores and the
-            # taxonomic information.
-            # We do this early so we notice issues before we start staging files.
-            if args.submit_bins or args.submit_mags:
-                bin_quality = get_bin_quality(config, silent=True)
-                # Test if there are bins which are too contaminated
-                for name in bin_quality.keys():
-                    contamination = bin_quality[name]['contamination']
-                    if contamination > staticConfig.max_contamination:
-                        err = (
-                            f"\nERROR: Bin {name} has a contamination score "
-                            f"of {contamination} which is higher than "
-                            f"{staticConfig.max_contamination}"
-                        )
-                        err += (
-                            "\nENA will reject the submission of this "
-                            "bin. Consult the 'Contamination above 100%' "
-                            "of README.md for more information."
-                        )
-                        loggingC.message(err, threshold=-1)
-                        exit(1)
-                bin_taxonomy = taxQuery.get_bin_taxonomy(config)
-            
-            # Construct depth files if there are .bam files in the config
-            if 'BAM_FILES' in config.keys():
-                bam_files = utility.from_config(config, 'BAM_FILES')
-                if not isinstance(bam_files, list):
-                    bam_files = [bam_files]
-                depth_files = utility.construct_depth_files(args.staging_dir,
-                                                            args.threads,
-                                                            bam_files)
-                bin_coverage_file = None
-            else:
-                if args.submit_bins:
-                    bin_coverage_file = utility.from_config(config,
-                                                            'BINS',
-                                                            'COVERAGE_FILE')
-                depth_files = None
+    try:        
+        sver = staticConfig.submg_version
+        wver = staticConfig.webin_cli_version
+        loggingC.message(f">Running submg {sver} with webin-cli {wver}", 0)
+        if args.development_service == 1:
+            loggingC.message((">Initializing a test submission to " \
+                               "the ENA dev server."), 0)
+        else:
+            loggingC.message((">Initializing a LIVE SUBMISSION to " \
+                               "the ENA production server."), 0)
+            time.sleep(5)
 
-            if args.submit_samples:
-                sample_accession_data = submit_samples(config,
-                                                args.staging_dir,
-                                                args.logging_dir,
-                                                test=args.development_service)
-                    
-                
-            else:
-                sample_accessions = utility.from_config(config,
-                                                        'SAMPLE_ACCESSIONS')
-                if not isinstance(sample_accessions, list):
-                    sample_accessions = [sample_accessions]
-                sample_accession_data = []
-                for acc in sample_accessions:
-                    sample_accession_data.append({
-                        'accession': acc,
-                        'external_accession': 'unk',
-                        'alias': 'unk',
-                    })
-                
-            if args.submit_reads:
-                run_accessions = submit_reads(config,
-                                              sample_accession_data,
-                                              prepdir(args.staging_dir, 'reads'),
-                                              prepdir(args.logging_dir, 'reads'),
-                                              test=args.development_service)
-            else:
-                run_accessions = utility.from_config(config, 'ASSEMBLY', 'RUN_ACCESSIONS')
-                if not isinstance(run_accessions, list):
-                    run_accessions = [run_accessions]
+        if not args.skip_checks:
+            utility.validate_parameter_combination(args.submit_samples,
+                                                   args.submit_reads,
+                                                   args.submit_assembly,
+                                                   args.submit_bins,
+                                                   args.submit_mags)
 
-            if args.submit_assembly:
-                assembly_sample_accession, assembly_fasta_accession = submit_assembly(config,
-                                                                                    args.staging_dir,
-                                                                                    args.logging_dir,
-                                                                                    depth_files,
-                                                                                    sample_accession_data,
-                                                                                    run_accessions,
-                                                                                    threads=args.threads,
-                                                                                    test=args.development_service)
-                # Assembly sample accession will be either the accession of the
-                # co-assembly virtual sample or the accession of the single sample
-                # which the assembly is based on
-            else:
-                if args.submit_bins or args.submit_mags:
-                    # In this case we need the submission of the sample that the
-                    # assembly is based on. We can derive it from the assembly
-                    # accession by querying ENA
-                    assembly_dict = utility.from_config(config, 'ASSEMBLY')
-                    assembly_sample_accession = None
-                    if 'EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION' in assembly_dict.keys():
-                        if not assembly_dict['EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION'] is None:
-                            assembly_sample_accession = assembly_dict['EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION']
-                    if 'EXISTING_ASSEMBLY_ANALYSIS_ACCESSION' in assembly_dict.keys():
-                        if not assembly_dict['EXISTING_ASSEMBLY_ANALYSIS_ACCESSION'] is None:
-                            assembly_analysis_accession = assembly_dict['EXISTING_ASSEMBLY_ANALYSIS_ACCESSION']
-                            assembly_sample_accession = enaSearching.search_samples_by_assembly_analysis(assembly_analysis_accession,
-                                                                                                        args.development_service)
+        config = preflight.preflight_checks(vars(args))
 
-            # Bin submision
+        # If we are submitting bins, get the quality scores and the
+        # taxonomic information.
+        # We do this early so we notice issues before we start staging files.
+        if args.submit_bins or args.submit_mags:
+            bin_quality = get_bin_quality(config, silent=True)
+            # Test if there are bins which are too contaminated
+            for name in bin_quality.keys():
+                contamination = bin_quality[name]['contamination']
+                if contamination > staticConfig.max_contamination:
+                    err = (
+                        f"\nERROR: Bin {name} has a contamination score "
+                        f"of {contamination} which is higher than "
+                        f"{staticConfig.max_contamination}"
+                    )
+                    err += (
+                        "\nENA will reject the submission of this "
+                        "bin. Consult the 'Contamination above 100%' "
+                        "of README.md for more information."
+                    )
+                    loggingC.message(err, threshold=-1)
+                    exit(1)
+            bin_taxonomy = taxQuery.get_bin_taxonomy(config)
+        
+        # Construct depth files if there are .bam files in the config
+        if 'BAM_FILES' in config.keys():
+            bam_files = utility.from_config(config, 'BAM_FILES')
+            if not isinstance(bam_files, list):
+                bam_files = [bam_files]
+            depth_files = utility.construct_depth_files(args.staging_dir,
+                                                        args.threads,
+                                                        bam_files)
+            bin_coverage_file = None
+        else:
             if args.submit_bins:
-                submit_bins(config,
-                            bin_taxonomy,
-                            assembly_sample_accession,
-                            run_accessions,
-                            prepdir(args.staging_dir, 'bins'),
-                            prepdir(args.logging_dir, 'bins'),
-                            depth_files,
-                            bin_coverage_file,
-                            threads=args.threads,
-                            test=args.development_service)
+                bin_coverage_file = utility.from_config(config,
+                                                        'BINS',
+                                                        'COVERAGE_FILE')
+            depth_files = None
+
+        if args.submit_samples:
+            sample_accession_data = submit_samples(config,
+                                                   args.staging_dir,
+                                                   args.logging_dir,
+                                                   test=args.development_service)
+                
+            
+        else:
+            sample_accessions = utility.from_config(config,
+                                                    'SAMPLE_ACCESSIONS')
+            if not isinstance(sample_accessions, list):
+                sample_accessions = [sample_accessions]
+            sample_accession_data = []
+            for acc in sample_accessions:
+                sample_accession_data.append({
+                    'accession': acc,
+                    'external_accession': 'unk',
+                    'alias': 'unk',
+                })
+            
+        if args.submit_reads:
+            run_accessions = submit_reads(config,
+                                          sample_accession_data,
+                                          prepdir(args.staging_dir, 'reads'),
+                                          prepdir(args.logging_dir, 'reads'),
+                                          test=args.development_service)
+        else:
+            run_accessions = utility.from_config(config, 'ASSEMBLY', 'RUN_ACCESSIONS')
+            if not isinstance(run_accessions, list):
+                run_accessions = [run_accessions]
+
+        if args.submit_assembly:
+            assembly_sample_accession, assembly_fasta_accession = submit_assembly(config,
+                                                                                  args.staging_dir,
+                                                                                  args.logging_dir,
+                                                                                  depth_files,
+                                                                                  sample_accession_data,
+                                                                                  run_accessions,
+                                                                                  threads=args.threads,
+                                                                                  test=args.development_service)
+            # Assembly sample accession will be either the accession of the
+            # co-assembly virtual sample or the accession of the single sample
+            # which the assembly is based on
+        else:
+            if args.submit_bins or args.submit_mags:
+                # In this case we need the submission of the sample that the
+                # assembly is based on. We can derive it from the assembly
+                # accession by querying ENA
+                assembly_dict = utility.from_config(config, 'ASSEMBLY')
+                assembly_sample_accession = None
+                if 'EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION' in assembly_dict.keys():
+                    if not assembly_dict['EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION'] is None:
+                        assembly_sample_accession = assembly_dict['EXISTING_CO_ASSEMBLY_SAMPLE_ACCESSION']
+                if 'EXISTING_ASSEMBLY_ANALYSIS_ACCESSION' in assembly_dict.keys():
+                    if not assembly_dict['EXISTING_ASSEMBLY_ANALYSIS_ACCESSION'] is None:
+                        assembly_analysis_accession = assembly_dict['EXISTING_ASSEMBLY_ANALYSIS_ACCESSION']
+                        assembly_sample_accession = enaSearching.search_samples_by_assembly_analysis(assembly_analysis_accession,
+                                                                                                    args.development_service)
+
+        # Bin submision
+        if args.submit_bins:
+            submit_bins(config,
+                        bin_taxonomy,
+                        assembly_sample_accession,
+                        run_accessions,
+                        prepdir(args.staging_dir, 'bins'),
+                        prepdir(args.logging_dir, 'bins'),
+                        depth_files,
+                        bin_coverage_file,
+                        threads=args.threads,
+                        test=args.development_service)
 
 
-            # MAG submission
-            if args.submit_mags:
-                if args.submit_assembly:
-                    metagenome_scientific_name = utility.from_config(config, 'METAGENOME_SCIENTIFIC_NAME')
-                else:
-                    try:
-                        metagenome_scientific_name = enaSearching.search_scientific_name_by_sample(assembly_sample_accession,
-                                                                                                   args.development_service)
-                    except:  
-                        # This is a workaround because I keep getting
-                        # false negatives on the development server
-                        # for samples that exist on both servers.
-                        metagenome_scientific_name = enaSearching.search_scientific_name_by_sample(assembly_sample_accession,
-                                                                                                   False)
-                submit_mags(config,
-                            metagenome_scientific_name,
-                            sample_accession_data,
-                            run_accessions,
-                            bin_taxonomy,
-                            prepdir(args.staging_dir, 'mags'),
-                            prepdir(args.logging_dir, 'mags'),
-                            depth_files,
-                            bin_coverage_file,
-                            threads=args.threads,
-                            test=args.development_service)
-
-            msg = "\n>All submissions completed."
-            if args.development_service:
-                msg += (
-                    "\n>This was a TEST submission to the ENA development "
-                    "server."
-                    "\n>You can check the status of your submission by "
-                    "logging into the development instance of the ENA "
-                    "submission website."
-                    "\n>Since this was a test submission, you will not "
-                    "receive final accessions via mail."
-                    "\n>Your data will be removed from the development "
-                    "server during the next 24 hours."
-                )
+        # MAG submission
+        if args.submit_mags:
+            if args.submit_assembly:
+                metagenome_scientific_name = utility.from_config(config, 'METAGENOME_SCIENTIFIC_NAME')
             else:
-                msg += (
-                    "\n>You will receive final accessions once your "
-                    "submission has been processed by ENA."
-                    "\n>ENA will send those final accession by email to "
-                    "the contact adress of your ENA account."
-                )
-            loggingC.message(msg, threshold=0)
+                try:
+                    metagenome_scientific_name = enaSearching.search_scientific_name_by_sample(assembly_sample_accession,
+                                                                                                args.development_service)
+                except:  
+                    # This is a workaround because I keep getting
+                    # false negatives on the development server
+                    # for samples that exist on both servers.
+                    metagenome_scientific_name = enaSearching.search_scientific_name_by_sample(assembly_sample_accession,
+                                                                                                False)
+            submit_mags(config,
+                        metagenome_scientific_name,
+                        sample_accession_data,
+                        run_accessions,
+                        bin_taxonomy,
+                        prepdir(args.staging_dir, 'mags'),
+                        prepdir(args.logging_dir, 'mags'),
+                        depth_files,
+                        bin_coverage_file,
+                        threads=args.threads,
+                        test=args.development_service)
 
-            # Cleanup
-            if not args.keep_depth_files and depth_files is not None:
-                loggingC.message(">Deleting depth files to free up disk space.", threshold=0)
-                for depth_file in depth_files:
-                    os.remove(depth_file)
+        msg = "\n>All submissions completed."
+        if args.development_service:
+            msg += (
+                "\n>This was a TEST submission to the ENA development "
+                "server."
+                "\n>You can check the status of your submission by "
+                "logging into the development instance of the ENA "
+                "submission website."
+                "\n>Since this was a test submission, you will not "
+                "receive final accessions via mail."
+                "\n>Your data will be removed from the development "
+                "server during the next 24 hours."
+            )
+        else:
+            msg += (
+                "\n>You will receive final accessions once your "
+                "submission has been processed by ENA."
+                "\n>ENA will send those final accession by email to "
+                "the contact adress of your ENA account."
+            )
+        loggingC.message(msg, threshold=0)
 
-        except Exception:
-            err = "\n\nTERMINATING BECAUSE AN UNHANDLED EXCEPTION OCCURED:\n"
-            loggingC.message(err, threshold=-1)
-            exc_info = traceback.format_exc()
-            loggingC.message(exc_info, threshold=-1)
-            exit(1)
+        # Cleanup
+        if not args.keep_depth_files and depth_files is not None:
+            loggingC.message(">Deleting depth files to free up disk space.", threshold=0)
+            for depth_file in depth_files:
+                os.remove(depth_file)
 
+    except Exception:
+        err = "\n\nTERMINATING BECAUSE AN UNHANDLED EXCEPTION OCCURED:\n"
+        loggingC.message(err, threshold=-1)
+        exc_info = traceback.format_exc()
+        loggingC.message(exc_info, threshold=-1)
+        exit(1)
+
+
+def main():
+    parser = init_argparse()
+    args = parser.parse_args()
+    if args.mode == 'download_webin':
+        download_webin()
+    elif args.mode == 'makecfg':
+        makecfg(args)
+    elif args.mode == 'submit':
+        submit(args)
     else:
         parser.print_help()
 

--- a/submg/main.py
+++ b/submg/main.py
@@ -130,7 +130,8 @@ def init_argparse():
                                            'containing the fields you need to '
                                            'fill out prior to submission')
     parser_makecfg.add_argument("-o",
-                                "--outfile",required=True,
+                                "--outfile",
+                                required=True,
                                 help="Path to the empty config that will be "
                                 "generated.")
     parser_makecfg.add_argument("-c",

--- a/submg/main.py
+++ b/submg/main.py
@@ -246,7 +246,7 @@ def submit(args):
         else:
             loggingC.message((">Initializing a LIVE SUBMISSION to " \
                                "the ENA production server."), 0)
-            time.sleep(5)
+            time.sleep(5) # Give user some extra time to notice message
 
         if not args.skip_checks:
             utility.validate_parameter_combination(args.submit_samples,
@@ -263,7 +263,7 @@ def submit(args):
         if args.submit_bins or args.submit_mags:
             bin_quality = get_bin_quality(config, silent=True)
             # If there are quality cutoffs, make a list of bins to submit
-            filtered_bins = utility.filter_bins(bin_quality, config)
+            filtered_bins = utility.quality_filter_bins(bin_quality, config)
             # Test if there are bins which are too contaminated
             for name in filtered_bins:
                 contamination = bin_quality[name]['contamination']
@@ -280,8 +280,10 @@ def submit(args):
                     )
                     loggingC.message(err, threshold=-1)
                     exit(1)
-            bin_taxonomy = taxQuery.get_bin_taxonomy(filtered_bins, config)
-        
+            # Query the taxonomy of bins
+            bin_taxonomy = taxQuery.get_bin_taxonomy(filtered_bins,
+                                                                    config)
+            
         # Construct depth files if there are .bam files in the config
         if 'BAM_FILES' in config.keys():
             bam_files = utility.from_config(config, 'BAM_FILES')

--- a/submg/preflight.py
+++ b/submg/preflight.py
@@ -711,7 +711,7 @@ def __check_mags(arguments: dict,
 
     # Check if all MAGs bins pass the filtering that is being applied to bins
     bin_quality = binSubmission.get_bin_quality(config, silent=True)
-    filtered_bins = utility.filter_bins(bin_quality, config)
+    filtered_bins = utility.quality_filter_bins(bin_quality, config)
     for bin_id in all_mag_bins:
         if bin_id not in filtered_bins:
             err = f"\nERROR: The bin {bin_id} in the MAG_METADATA_FILE does not pass the filtering criteria for bins (MIN_COMPLETENESS / MAX_CONTAMINATION)."

--- a/submg/preflight.py
+++ b/submg/preflight.py
@@ -2,7 +2,7 @@ import os
 
 from datetime import datetime
 
-from submg import loggingC, utility, enaSearching
+from submg import loggingC, utility, enaSearching, binSubmission, taxQuery
 from submg.statConf import staticConfig
 from submg.webinWrapper import find_webin_cli_jar
 from submg.taxQuery import taxid_from_scientific_name
@@ -22,6 +22,7 @@ def __check_tsv(tsvfile: str,
         required_columns:   A list of column names that must be present in the
                             .tsv file.
     """
+    global checks_failed
     if not os.path.isfile(tsvfile):
         err = f"\nERROR: The .tsv file '{tsvfile}' does not exist."
         loggingC.message(err, threshold=-1)
@@ -30,7 +31,7 @@ def __check_tsv(tsvfile: str,
         header = f.readline().strip().split('\t')
     for col in required_columns:
         if col not in header:
-            err = f"\nWARNING: The .tsv file '{tsvfile}' is missing the column '{col}'."
+            err = f"\nERROR: The .tsv file '{tsvfile}' is missing the column '{col}'."
             loggingC.message(err, threshold=-1)
             checks_failed = True
     if 'Bin_ids' in header:
@@ -545,11 +546,50 @@ def __check_bins(arguments: dict,
         checks_failed = True
     __check_tsv(quality_file, staticConfig.bin_quality_columns.split(';'))
 
+    # Check if the quality filtering criteria are defined and whether they
+    # look right (they are positive, between 0 and 100, they are not floats < 1)
+    if 'MIN_COMPLETENESS' in bin_data.keys():
+        try:
+            min_completeness = float(bin_data['MIN_COMPLETENESS'])
+            if min_completeness < 0 or min_completeness > 100:
+                err = f"ERROR: The MIN_COMPLETENESS value is not between 0 and 100."
+                loggingC.message(err, threshold=-1)
+                checks_failed = True
+            if min_completeness < 1:
+                err = f"ERROR: The MIN_COMPLETENESS value is smaller than 1. Completeness needs to be defined as percent points (0-100)."
+                loggingC.message(err, threshold=-1)
+                checks_failed = True
+        except ValueError:
+            err = f"ERROR: The MIN_COMPLETENESS value {bin_data['MIN_COMPLETENESS']} is not a number."
+            loggingC.message(err, threshold=-1)
+            checks_failed = True
+
+    if 'MAX_CONTAMINATION' in bin_data.keys():
+        try:
+            max_contamination = float(bin_data['MAX_CONTAMINATION'])
+            if max_contamination < 0 or max_contamination > 100:
+                err = f"ERROR: The MAX_CONTAMINATION value is not between 0 and 100."
+                loggingC.message(err, threshold=-1)
+                checks_failed = True
+            if max_contamination < 1:
+                err = f"ERROR: The MAX_CONTAMINATION value is smaller than 1. Contamination needs to be defined as percent points (0-100)."
+                loggingC.message(err, threshold=-1)
+                checks_failed = True
+        except ValueError:
+            err = f"ERROR: The MAX_CONTAMINATION value {bin_data['MAX_CONTAMINATION']} is not a number."
+            loggingC.message(err, threshold=-1)
+            checks_failed = True
+
 
     # Check if at least one NCBI_TAXONOMY_FILE or MANUAL_TAXONOMY_FILE exists
     tax_files = []
     if 'NCBI_TAXONOMY_FILES' in bin_data.keys():
         ncbi_tax_files = bin_data['NCBI_TAXONOMY_FILES']
+        if ncbi_tax_files is None:
+            err = f"\nERROR: The field NCBI_TAXONOMY_FILES in the BINS section is empty."
+            err += f"\nPlease provide a valid file path or remove the field from the config file."
+            loggingC.message(err, threshold=-1)
+            exit(1) # We cannot carry out the rest of the preflight checks
         if not isinstance(ncbi_tax_files, list):
             ncbi_tax_files = [ncbi_tax_files]
         tax_files.extend(ncbi_tax_files)
@@ -581,10 +621,12 @@ def __check_bins(arguments: dict,
                 loggingC.message(err, threshold=-1)
                 checks_failed = True
             __check_tsv(bin_data['MANUAL_TAXONOMY_FILE'], staticConfig.manual_taxonomy_columns.split(';'))
+            if not taxQuery.check_manual_taxonomies(bin_data['MANUAL_TAXONOMY_FILE']):
+                checks_failed = True
             tax_files.append(bin_data['MANUAL_TAXONOMY_FILE'])
     # And if the headers of the MANUAL_TAXONOMY_FILE are correct
             
-    # Now check there actual are tax files
+    # Now check if there actual are tax files
     if len(tax_files) == 0:
         err = f"\nERROR: You chose to submit bins, but did not provide any taxonomy files."
         loggingC.message(err, threshold=-1)
@@ -639,6 +681,7 @@ def __check_mags(arguments: dict,
     utility.stamped_from_config(config, 'PROJECT_NAME')
 
     # Check the metadata file
+    all_mag_bins = set()
     metadata_file = utility.from_config(config, 'MAGS', 'MAG_METADATA_FILE')
     if metadata_file is None or metadata_file == '':
         err = f"\nERROR: No MAG_METADATA_FILE was provided in the MAGS section."
@@ -650,6 +693,7 @@ def __check_mags(arguments: dict,
         reader = csv.DictReader(f, delimiter='\t')
         for row in reader:
             bin_id = row['Bin_id'].strip()
+            all_mag_bins.add(bin_id)
             if bin_id == '' or bin_id is None:
                 err = f"\nERROR: The metadata file '{metadata_file}' contains an empty bin_id field."
                 loggingC.message(err, threshold=-1)
@@ -664,6 +708,15 @@ def __check_mags(arguments: dict,
                     err = f"\nERROR: Error reading '{metadata_file}' at Bin_id {bin_id}. If you provide an Unlocalised_path, you need to provide a Chromosomes_path as well."
                     loggingC.message(err, threshold=-1)
                     exit(1)
+
+    # Check if all MAGs bins pass the filtering that is being applied to bins
+    bin_quality = binSubmission.get_bin_quality(config, silent=True)
+    filtered_bins = utility.filter_bins(bin_quality, config)
+    for bin_id in all_mag_bins:
+        if bin_id not in filtered_bins:
+            err = f"\nERROR: The bin {bin_id} in the MAG_METADATA_FILE does not pass the filtering criteria for bins (MIN_COMPLETENESS / MAX_CONTAMINATION)."
+            loggingC.message(err, threshold=-1)
+            exit(1)
 
     # Check fields in ASSEMBLY section
     assembly_data = utility.from_config(config, 'ASSEMBLY')
@@ -828,11 +881,11 @@ def preflight_checks(arguments: dict) -> None:
         exit(1)
 
     if checks_failed:
-        msg = f"Some preflight checks failed. If you are sure that the data " \
+        msg = f"\nSome preflight checks failed. If you are sure that the data " \
                 "you provided is correct, you can skip these checks by using " \
                 "the --skip_checks flag. If any ERROR messages are not " \
-                "adressed, they are likely to cause failure after partial " \
-                "submission."
+                "adressed, they are likely to cause failure, sometimes after " \
+                "partial submission of the data."
         loggingC.message(msg, threshold=-1)
         exit(1)
     else:

--- a/submg/readSubmission.py
+++ b/submg/readSubmission.py
@@ -143,7 +143,8 @@ def submit_reads(config,
                  sample_accession_data,
                  staging_dir,
                  logging_dir,
-                 test=True):
+                 test=True,
+                 minitest=False):
     """
     Submits the specified reads to ENA.
 
@@ -180,6 +181,10 @@ def submit_reads(config,
             if not name in read_manifests:
                 read_manifests[name] = manifest  
             counter = i + 1
+            if minitest:
+                msg = ">Minitest: Only submitting the first paired-end read set."
+                loggingC.message(msg, threshold=0)
+                break
 
     if 'SINGLE_READS' in config.keys():
         loggingC.message(">Staging single-end reads for submission. This might take a while.", threshold=0)
@@ -197,7 +202,11 @@ def submit_reads(config,
                                                 read_set_logging_dir)         
             
             if not name in read_manifests:
-                read_manifests[name] = manifest                                       
+                read_manifests[name] = manifest    
+            if minitest:
+                msg = ">Minitest: Only submitting the first single-end read set."
+                loggingC.message(msg, threshold=0)
+                break                                
 
     # Upload the reads
     loggingC.message(f">Using ENA Webin-CLI to submit reads.", threshold=0)

--- a/submg/statConf.py
+++ b/submg/statConf.py
@@ -108,9 +108,9 @@ YAMLCOMMENTS = {
     'COVERAGE_VALUE': "Read coverage of the assembly.",
     'COVERAGE_FILE': ".tsv file containing the coverage values of each bin. Columns must be 'Bin_id' and 'Coverage'.",
     'INSERT_SIZE': "Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html)",
-    'MAG_METADATA_FILE': "A .tsv specifying 'Bin_id', 'Sample_id', 'Quality_category', 'Flatfile_path', 'Chromosomes_path' and 'Unlocalised_path' for all MAGs. See README for more details."
-    'MIN_COMPLETENESS': "Bins with smaller completeness value will be discarded (in percent, 0-100). Remove this row to ignore bin completeness".
-    'MAX_CONTAMINATION': "Bins with larger contamination value will be discarded (in percent, 0-100). Remove this row to ignore bin contamination",
+    'MAG_METADATA_FILE': "A .tsv specifying 'Bin_id', 'Sample_id', 'Quality_category', 'Flatfile_path', 'Chromosomes_path' and 'Unlocalised_path' for all MAGs. See README for more details.",
+    'MIN_COMPLETENESS': "Bins with smaller completeness value will be discarded (in percent, 0-100). Remove this row to ignore bin completeness.",
+    'MAX_CONTAMINATION': "Bins with larger contamination value will be discarded (in percent, 0-100). Remove this row to ignore bin contamination (>100% contamination bins will still be discarded).",
 }
 
 YAMLEXAMPLES = {

--- a/submg/statConf.py
+++ b/submg/statConf.py
@@ -109,6 +109,8 @@ YAMLCOMMENTS = {
     'COVERAGE_FILE': ".tsv file containing the coverage values of each bin. Columns must be 'Bin_id' and 'Coverage'.",
     'INSERT_SIZE': "Insert size of the paired-end reads (https://www.ebi.ac.uk/fg/annotare/help/seq_lib_spec.html)",
     'MAG_METADATA_FILE': "A .tsv specifying 'Bin_id', 'Sample_id', 'Quality_category', 'Flatfile_path', 'Chromosomes_path' and 'Unlocalised_path' for all MAGs. See README for more details."
+    'MIN_COMPLETENESS': "Bins with smaller completeness value will be discarded (in percent, 0-100). Remove this row to ignore bin completeness".
+    'MAX_CONTAMINATION': "Bins with larger contamination value will be discarded (in percent, 0-100). Remove this row to ignore bin contamination",
 }
 
 YAMLEXAMPLES = {
@@ -153,5 +155,7 @@ YAMLEXAMPLES = {
         'taxonomic identity marker': '\"multi marker approach\"',
         'MAG_METADATA_FILE': '\"/mnt/data/mag_data.tsv\"',
         'INSERT_SIZE': '\"300\"',
+        'MIN_COMPLETENESS': '\"90\"',
+        'MAX_CONTAMINATION': '\"5\"',
     }
 

--- a/submg/taxQuery.py
+++ b/submg/taxQuery.py
@@ -24,7 +24,9 @@ def __report_tax_issues(issues):
     problematic_bins = set(problematic_bins)
     msg = '\n'.join(problematic_bins)
     loggingC.message(msg, threshold=-1)
-    msg = "Please consult the README. You can manually enter taxonomy data for these bins into a .tsv file and specify it in the MANUAL_TAXONOMY_FILE field in the config file."
+    msg =  "Please consult the README. You can manually enter taxonomy data for these bins into a .tsv file and specify it in the MANUAL_TAXONOMY_FILE field in the config file."
+    msg += " If your annotation process failed to classify a bin even at domain level, consider excluding it from your submission. If you want to submit it anyways,"
+    msg += " you may choose to add it to the MANUAL_TAXONOMY_FILES using taxid 155900 (unclassified organism)."
     loggingC.message(msg, threshold=-1) 
 
     # Give a detailed listing of the issues
@@ -278,7 +280,7 @@ def __best_classification(ncbi_classifications: dict) -> dict:
     return result
 
 
-def ena_taxonomy_suggestion(level: str,
+def __ena_taxonomy_suggestion(level: str,
                             domain: str,
                             classification: str,
                             filtered: bool = True) -> list:
@@ -472,7 +474,7 @@ def get_bin_taxonomy(filtered_bins, config) -> dict:
         if bin_name in upload_taxonomy_data:
             loggingC.message(f">INFO: Bin {bin_name} was found in the manual taxonomy file and will be skipped.", threshold=1)
             continue
-        suggestions = ena_taxonomy_suggestion(taxonomy['level'],
+        suggestions = __ena_taxonomy_suggestion(taxonomy['level'],
                                               taxonomy['domain'],
                                               taxonomy['classification'],
                                               filtered=True)
@@ -482,7 +484,7 @@ def get_bin_taxonomy(filtered_bins, config) -> dict:
                 'tax_id': suggestions[0]['tax_id'],
             }
         else:
-            all_ena_suggestions = ena_taxonomy_suggestion(taxonomy['level'],
+            all_ena_suggestions = __ena_taxonomy_suggestion(taxonomy['level'],
                                                           taxonomy['domain'],
                                                           taxonomy['classification'],
                                                           filtered=False)

--- a/submg/taxQuery.py
+++ b/submg/taxQuery.py
@@ -22,9 +22,10 @@ def __report_tax_issues(issues):
     loggingC.message(err, threshold=-1)
     problematic_bins = [x['mag_bin'] for x in issues]
     problematic_bins = set(problematic_bins)
-    msg = '\n'.join(problematic_bins)
+    msg = "\t"+'\n\t'.join(problematic_bins)
     loggingC.message(msg, threshold=-1)
-    msg =  "Please consult the README. You can manually enter taxonomy data for these bins into a .tsv file and specify it in the MANUAL_TAXONOMY_FILE field in the config file."
+    msg =  "Please consult the Taxonomy Assignment section of the README."
+    msg += "\nYou can manually enter taxonomy data for these bins into a .tsv file and specify it in the MANUAL_TAXONOMY_FILE field in the config file."
     msg += " If your annotation process failed to classify a bin even at domain level, consider excluding it from your submission. If you want to submit it anyways,"
     msg += " you may choose to add it to the MANUAL_TAXONOMY_FILES using taxid 155900 (unclassified organism)."
     loggingC.message(msg, threshold=-1) 

--- a/submg/utility.py
+++ b/submg/utility.py
@@ -411,10 +411,11 @@ def quality_filter_bins(quality_data, config):
     if len(filtered_out) > 0:
         msg = f">WARNING: {len(filtered_out)} bins have been excluded from submission due to quality thresholds:"
         loggingC.message(msg, threshold=0)
-        time.sleep(5) # Give user some extra time to notice message
     for bin in filtered_out:
         msg = f"\t{bin} (completeness {quality_data[bin]['completeness']}, contamination {quality_data[bin]['contamination']})"
         loggingC.message(msg, threshold=0)
+    if len(filtered_out) > 0:
+        time.sleep(5) # Give user some extra time to notice message
     if len(filtered_bins) == 0:
         err = "\nERROR: No bins left after filtering. Please adjust the quality thresholds."
         loggingC.message(err, threshold=-1)

--- a/submg/utility.py
+++ b/submg/utility.py
@@ -589,6 +589,7 @@ def validate_parameter_combination(submit_samples: bool,
         is_valid = True
 
     if not is_valid:
+        # Dont use loggingC here because this might be called from configGen
         print(f"\nERROR: The combination of parameters you have specified is not valid.")
         print(staticConfig.submission_modes_message)
         exit(1)

--- a/submg/utility.py
+++ b/submg/utility.py
@@ -376,7 +376,7 @@ def check_fasta(fasta_path) -> tuple:
     return fasta_path, gzipped
 
 
-def filter_bins(quality_data, config):
+def quality_filter_bins(quality_data, config):
     """
     Filter bins based on the quality data.
 

--- a/submg/utility.py
+++ b/submg/utility.py
@@ -136,12 +136,14 @@ def api_response_check(response: requests.Response):
         loggingC.message(err, threshold=-1)
         exit(1)
 
+
 def calculate_md5(fname):
     hash_md5 = hashlib.md5()
     with open(fname, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
+
 
 def get_login():
     """
@@ -157,6 +159,7 @@ def get_login():
         exit(1)
     return os.environ['ENA_USER'], os.environ['ENA_PASSWORD']
 
+
 def read_yaml(file_path):
     try:
         with open(file_path, 'r') as yaml_file:
@@ -170,6 +173,7 @@ def read_yaml(file_path):
         err = f"\nERROR: An error occurred while reading {file_path}, error is:\n{e}"
         loggingC.message(err, threshold=-1)
         exit(1)
+
 
 def __strcast(value):
     """
@@ -199,7 +203,8 @@ def prepdir(parent_path, name):
     newdir = os.path.join(parent_path, name)
     os.makedirs(newdir, exist_ok=False)
     return newdir
-    
+
+
 def from_config(config, key, subkey=None, subsubkey=None, supress_errors=False):
     """
     Extracts a value from the dict that was created based on the
@@ -259,6 +264,7 @@ def from_config(config, key, subkey=None, subsubkey=None, supress_errors=False):
         return __strcast(config[key][subkey])
     return __strcast(config[key])
 
+
 def optional_from_config(config, key, subkey=None, subsubkey=None):
     """
     Calls from config but returns None if the key is missing.
@@ -274,6 +280,7 @@ def optional_from_config(config, key, subkey=None, subsubkey=None):
     except:
         return None
     
+
 def stamped_from_config(config, key, subkey=None, subsubkey=None):
     """
     Calls from config but adds a timestamp to relevant fields if timestamping
@@ -337,6 +344,7 @@ def is_fasta(filepath, extensions=staticConfig.fasta_extensions.split(';')) -> s
     basename = filename.rsplit('.', 1)[0]
     return basename
 
+
 def check_fasta(fasta_path) -> tuple:
     """
     Checks if the fasta file exists, has a valid extension and whether it is
@@ -366,6 +374,52 @@ def check_fasta(fasta_path) -> tuple:
         loggingC.message(err, threshold=-1)
         exit(1)
     return fasta_path, gzipped
+
+
+def filter_bins(quality_data, config):
+    """
+    Filter bins based on the quality data.
+
+    Args:
+        quality_data (dict): The quality data for the bins.
+    """
+    filtered_bins = []
+
+    # Check arguments in config
+    if 'MIN_COMPLETENESS' in config['BINS']:
+        min_completeness = config['BINS']['MIN_COMPLETENESS']
+        msg = f">Filtering bins based on minimum completeness of {min_completeness}."
+    else:
+        min_completeness = 0
+        msg = ">No MIN_COMPLETENESS specified, bins will not be filtered for completeness."
+    loggingC.message(msg, threshold=0)
+    if 'MAX_CONTAMINATION' in config['BINS']:
+        max_contamination = config['BINS']['MAX_CONTAMINATION']
+        msg = f">Filtering bins based on maximum contamination of {max_contamination}."
+    else:
+        max_contamination = 100
+        msg = ">No MAX_CONTAMINATION specified, maximum contamination is set to 100."
+    loggingC.message(msg, threshold=0)
+
+    # Filtering
+    filtered_out = []
+    for bin in quality_data:
+        if quality_data[bin]['completeness'] >= min_completeness and quality_data[bin]['contamination'] <= max_contamination:
+            filtered_bins.append(bin)
+        else:
+            filtered_out.append(bin)
+    if len(filtered_out) > 0:
+        msg = f">WARNING: {len(filtered_out)} bins have been excluded from submission due to quality thresholds:"
+        loggingC.message(msg, threshold=0)
+        time.sleep(5) # Give user some extra time to notice message
+    for bin in filtered_out:
+        msg = f"\t{bin} (completeness {quality_data[bin]['completeness']}, contamination {quality_data[bin]['contamination']})"
+        loggingC.message(msg, threshold=0)
+    if len(filtered_bins) == 0:
+        err = "\nERROR: No bins left after filtering. Please adjust the quality thresholds."
+        loggingC.message(err, threshold=-1)
+        exit(1)
+    return filtered_bins
 
 
 def check_bam(bam_file,
@@ -408,6 +462,7 @@ def check_bam(bam_file,
 
     return sorted_bam_file  
 
+
 def make_depth_file(bam_file, outdir, num_threads=4):
     """
     Uses pysam.depth to call samtools depth and create a depth file with
@@ -425,6 +480,7 @@ def make_depth_file(bam_file, outdir, num_threads=4):
     outfile = os.path.join(outdir, filename)
     pysam.depth("-@", str(num_threads), "-a", sorted_bam_file, "-o", outfile)
     return outfile
+
 
 def contigs_coverage(depth_file):
     """
@@ -451,6 +507,7 @@ def contigs_coverage(depth_file):
         if position > contig_length[contig]: # Contig positions should be ordered, so we just need the last one. But we do this just to be safe
             contig_length[contig] = position
     return contig_coverage, contig_length
+
 
 def calculate_coverage(depth_files: list,
                        target_contigs: set = None,
@@ -589,7 +646,7 @@ def validate_parameter_combination(submit_samples: bool,
         is_valid = True
 
     if not is_valid:
-        # Dont use loggingC here because this might be called from configGen
+        # Dont use loggingC here, because this might be called from configGen
         print(f"\nERROR: The combination of parameters you have specified is not valid.")
         print(staticConfig.submission_modes_message)
         exit(1)

--- a/todo.txt
+++ b/todo.txt
@@ -15,9 +15,10 @@
 [x] Preflight checks überarbeiten, so dass ich mehrere ERRORs auf einmal sehen kann
 
 >> RELEASE 1.0.0
+[ ] Refactor main.py 
 [ ] Antworten auf meine ENA tickets
 [ ] minitest-option - wir uploaden nur 1 readfile, nur 1 bin, simulieren coverage werte
-[ ] enaSearching überarbeiten - kann ich wirklich nicht auf dem dev server suchen?
+[x] enaSearching überarbeiten - kann ich wirklich nicht auf dem dev server suchen?
 
 >> RELEASE irgendwann
 [ ] preflight macht erst alle preflight checks, reported alle probleme. Erst dann passiert exit(1).-


### PR DESCRIPTION
Completed all 0.9.2 tasks:
  - Added filtering of low quality bins prior to submission, added corresponding --quality_cutoffs argument to makecfg
  - Added --minitest argument to enable quick testing of the input parameters without the need to process a complete dataset
  - Adjusted the reporting for bins that cannot be submitted due to low quality or missing taxonomic information
  - When a user chooses to specify taxonomy manually, preflight checks now include ENA queries to make sure the taxids and scientific names specified be the user match up
  - Additional improvements for preflight checks
  - Updated README